### PR TITLE
Fix misspelling when checking cuda availbility

### DIFF
--- a/model.py
+++ b/model.py
@@ -50,7 +50,7 @@ class Word2Vec(Bundler):
 
     def forward_o(self, data):
         v = V(LT(data), requires_grad=False)
-        v = v.cuda() if self.ivectors.weight.is_cuda else v
+        v = v.cuda() if self.ovectors.weight.is_cuda else v
         return self.ovectors(v)
 
 


### PR DESCRIPTION
Hi, While I try to understand the model part, I think I found some misspelling. I think we should have to check the cuda availability for ovectors.weight